### PR TITLE
Reduced log level when SSO entry is not found

### DIFF
--- a/agents/josso-servlet-agent/src/main/java/org/josso/servlet/agent/GenericServletSSOAgentFilter.java
+++ b/agents/josso-servlet-agent/src/main/java/org/josso/servlet/agent/GenericServletSSOAgentFilter.java
@@ -428,8 +428,8 @@ public class GenericServletSSOAgentFilter implements Filter {
                 SingleSignOnEntry entry = agent.processRequest(relayRequest);
                 if (entry == null) {
                     // This is wrong! We should have an entry here!
-                    log.error("Outbound relaying failed for assertion id [" + assertionId + "], no Principal found.");
-                    // Throw an exception and let the container send the INERNAL SERVER ERROR
+                    log.debug("Outbound relaying failed for assertion id [" + assertionId + "], no Principal found.");
+                    // Throw an exception and let the container deal with it
                     throw new ServletException("No Principal found. Verify your SSO Agent Configuration!");
                 }
 


### PR DESCRIPTION
We get a lot of duplicated log messages in our error log because the filter and container are both logging about the same thing. This changes the logging of the detailed message to debug.
