### PR TITLE
Fix memory leak caused by Tomcat 7 session fixation protection

### DIFF
--- a/agents/josso-tomcat70-agent/pom.xml
+++ b/agents/josso-tomcat70-agent/pom.xml
@@ -38,7 +38,7 @@
     <description>Tomcat 7 Agent</description>
 
     <properties>
-        <tomcat-version>7.0.5</tomcat-version>
+        <tomcat-version>7.0.53</tomcat-version>
     </properties>
 
 

--- a/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/CatalinaLocalSession.java
+++ b/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/CatalinaLocalSession.java
@@ -37,8 +37,11 @@ public class CatalinaLocalSession extends LocalSessionImpl {
 
        setWrapped(catalinaSession);
        setMaxInactiveInterval(catalinaSession.getMaxInactiveInterval());
-
-
+    }
+    
+    @Override
+    public String toString() {
+        return "CatalinaLocalSession [toString()=" + super.toString() + "]";
     }
 
 }

--- a/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/CatalinaSSOAgent.java
+++ b/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/CatalinaSSOAgent.java
@@ -25,6 +25,8 @@ package org.josso.tc70.agent;
 import org.apache.catalina.Container;
 import org.apache.catalina.Context;
 import org.apache.catalina.Realm;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.josso.agent.SSOAgentRequest;
 import org.josso.agent.http.HttpSSOAgent;
 
@@ -41,6 +43,8 @@ import java.security.Principal;
  */
 public class CatalinaSSOAgent extends HttpSSOAgent {
 
+    private static final Log LOG = LogFactory.getLog(CatalinaSSOAgent.class);
+            
     private Container _container;
 
     public CatalinaSSOAgent() {
@@ -101,19 +105,11 @@ public class CatalinaSSOAgent extends HttpSSOAgent {
     }
 
     protected void log(String message) {
-        if (_container != null) {
-            if (_container.getLogger().isDebugEnabled())
-            _container.getLogger().debug(this.toString() + ": " + message);
-        } else
-            System.out.println(this.toString() + ": " + message);
+        LOG.debug(message);
     }
 
     protected void log(String message, Throwable throwable) {
-        if (_container != null) {
-            if (_container.getLogger().isDebugEnabled())
-                _container.getLogger().debug(this.toString() + ": " + message, throwable);
-        } else
-            System.out.println(this.toString() + ": " + message);
+        LOG.debug(message, throwable);
     }
 
     /**

--- a/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/LocalSessionImpl.java
+++ b/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/LocalSessionImpl.java
@@ -103,5 +103,11 @@ public class LocalSessionImpl implements LocalSession {
     public Object getWrapped() {
         return _wrapped;
     }
-}
 
+    @Override
+    public String toString() {
+        return "LocalSessionImpl [_creationTime=" + _creationTime + ", _id=" + _id + ", _lastAccessedTime="
+                + _lastAccessedTime + ", _maxInactiveInterval=" + _maxInactiveInterval + ", _wrapped=" + _wrapped + "]";
+    }
+
+}

--- a/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/SSOAgentValve.java
+++ b/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/SSOAgentValve.java
@@ -22,24 +22,46 @@
 
 package org.josso.tc70.agent;
 
-import org.apache.catalina.*;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleListener;
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.Manager;
+import org.apache.catalina.Realm;
+import org.apache.catalina.Session;
+import org.apache.catalina.SessionEvent;
+import org.apache.catalina.SessionListener;
 import org.apache.catalina.authenticator.SavedRequest;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.deploy.SecurityConstraint;
 import org.apache.catalina.util.LifecycleSupport;
 import org.apache.catalina.valves.ValveBase;
-import org.josso.agent.*;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.josso.agent.Constants;
+import org.josso.agent.LocalSession;
+import org.josso.agent.Lookup;
+import org.josso.agent.SSOAgentRequest;
+import org.josso.agent.SSOPartnerAppConfig;
+import org.josso.agent.SingleSignOnEntry;
 import org.josso.agent.http.WebAccessControlUtil;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import java.io.IOException;
-import java.util.*;
-
 
 /**
  * Single Sign-On Agent implementation for Tomcat Catalina.
@@ -49,6 +71,8 @@ import java.util.*;
  */
 public class SSOAgentValve extends ValveBase
         implements Lifecycle, SessionListener {
+
+    private static final Log LOG = LogFactory.getLog(SSOAgentValve.class);
 
     /**
      * The debugging detail level for this component.
@@ -77,7 +101,7 @@ public class SSOAgentValve extends ValveBase
     /**
      * Catalina Session to Local Session Map.
      */
-    Map _sessionMap = Collections.synchronizedMap(new HashMap());
+    private Map<String, LocalSession> _sessionMap = Collections.synchronizedMap(new HashMap<String, LocalSession>());
 
     // ------------------------------------------------------------- Properties
 
@@ -106,15 +130,95 @@ public class SSOAgentValve extends ValveBase
 
     public void sessionEvent(SessionEvent event) {
 
-
-        // obtain the local session for the catalina session, and notify the listeners for it.
-        LocalSession localSession = (LocalSession) _sessionMap.get(event.getSession().getId());
-
-        if (event.getType().equals(Session.SESSION_DESTROYED_EVENT)) {
-            localSession.expire();
-            _sessionMap.remove(event.getSession().getId());
+        if (LOG.isInfoEnabled()) {
+            LOG.info("JOSSO: SSOAgentValve.sessionEvent: " + event);
         }
-            
+
+        // extra protective guard
+        try {
+            // obtain the local session for the catalina session, and notify the
+            // listeners for it.
+            LocalSession localSession = _sessionMap.get(event.getSession().getId());
+
+            if (event.getType().equals(Session.SESSION_DESTROYED_EVENT)) {
+                // This was the main bug
+                if (localSession != null) {
+                    localSession.expire();
+                    LOG.info("JOSSO: SSOAgentValve.sessionEvent: session not null. can expire.");
+                } else {
+                    LOG.info("JOSSO: SSOAgentValve.sessionEvent: session is null. using brute force.");
+
+                    String foundId = null;
+
+                    Session eventSession = event.getSession();
+                    String authType = eventSession.getAuthType();
+                    long creationTime = eventSession.getCreationTime();
+                    String id = eventSession.getId();
+                    Principal p = eventSession.getPrincipal();
+
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("JOSSO: SSOAgentValve.sessionEvent: eventSession: authType=" + authType
+                                + ", creationTime=" + creationTime + ", id=" + id + ", Principal=" + p);
+
+                    // free any sessions that can't be looked up
+                    synchronized (_sessionMap) {
+                        for (Entry<String, LocalSession> ks : _sessionMap.entrySet()) {
+                            String key = ks.getKey();
+                            LocalSession mapSession = ks.getValue();
+
+                            if (LOG.isDebugEnabled())
+                                LOG.debug("JOSSO: SSOAgentValve.sessionEvent: _sessionMap: key: " + key + ", value: "
+                                        + mapSession);
+
+                            Object mapWrapped = mapSession.getWrapped();
+                            if (mapWrapped instanceof Session) {
+                                Session mapS = (Session) mapWrapped;
+                                String mapAuthType = mapS.getAuthType();
+                                long mapCreationTime = mapS.getCreationTime();
+                                String mapId = mapS.getId();
+                                Principal mapP = mapS.getPrincipal();
+
+                                if (LOG.isDebugEnabled())
+                                    LOG.debug("JOSSO: SSOAgentValve.sessionEvent: mapWrapped Session: authType="
+                                            + mapAuthType + ", creationTime=" + mapCreationTime + ", id=" + mapId
+                                            + ", Principal=" + mapP);
+
+                                if (creationTime == mapCreationTime && id != null && id.equals(mapId)) {
+
+                                    if (LOG.isDebugEnabled())
+                                        LOG.debug("JOSSO: SSOAgentValve.sessionEvent: Found ID match: " + key);
+
+                                    foundId = key;
+                                    break;
+                                }
+                            }
+
+                        }
+
+                        if (foundId != null) {
+                            _sessionMap.remove(foundId);
+                            if (LOG.isInfoEnabled())
+                                LOG.info("JOSSO: SSOAgentValve.sessionEvent: removed by brute force: " + foundId);
+                        }
+
+                    }
+
+                }
+
+                _sessionMap.remove(event.getSession().getId());
+
+                if (LOG.isInfoEnabled())
+                    LOG.info("JOSSO: SSOAgentValve.sessionEvent: sessionMap.size remaining: " + _sessionMap.size());
+            }
+
+        } catch (
+
+        Exception ex) {
+            LOG.error("JOSSO: SESSION FIX EXCEPTION: ", ex);
+        }
+
+        LOG.debug("JOSSO: SSOAgentValve.sessionEvent: complete");
+
     }
 
     // ------------------------------------------------------ Lifecycle Methods
@@ -388,7 +492,7 @@ public class SSOAgentValve extends ValveBase
             String jossoSessionId = (cookie == null) ? null : cookie.getValue();
             if (debug >= 1)
                 log("Session is: " + session);
-            LocalSession localSession = (LocalSession) _sessionMap.get(session.getId());
+            LocalSession localSession = _sessionMap.get(session.getId());
             if (localSession == null) {
                 localSession = new CatalinaLocalSession(session);
                 // the local session is new so, make the valve listen for its events so that it can
@@ -687,7 +791,7 @@ public class SSOAgentValve extends ValveBase
             // some stuff and invoke the next valve in the chain always ...
 
             // Store this error, it will be checked by the ErrorReportingValve
-            request.setAttribute(Globals.EXCEPTION_ATTR, t);
+            request.setAttribute(RequestDispatcher.ERROR_EXCEPTION, t);
 
             // Mark this response as error!
             response.setError();


### PR DESCRIPTION
First, I don't expect this to be merged as-is and it's not the ideal solution so this is sort of for demonstration purposes. Also, this fixes the problem for my particular environment (tomcat version, josso version) in an acceptable, short-term way.  Seemingly no one else has ever run into this problem, so maybe this is specific to my environment and something is just configured incorrectly. However, after looking at the code, I don't see how no one else can be experiencing this problem. 

**The problem:**
If you occasionally find tomcat freezes and needs a restart for 'unknown' or out of memory errors, or see following error in tomcat.log, then this fix may work for you.

```
17 Aug 2016 14:42:24,916 (ContainerBackgroundProcessor[StandardEngine[Catalina]])  WARN ContainerBase(1354) | Exception processing manager org.apache.catalina.session.StandardManager[/myapp] background process
java.lang.NullPointerException
        at org.josso.tc70.agent.SSOAgentValve.sessionEvent(SSOAgentValve.java:114)
        at org.apache.catalina.session.StandardSession.fireSessionEvent(StandardSession.java:1752)
        at org.apache.catalina.session.StandardSession.expire(StandardSession.java:843)
        at org.apache.catalina.session.StandardSession.isValid(StandardSession.java:656)
        at org.apache.catalina.session.ManagerBase.processExpires(ManagerBase.java:532)
        at org.apache.catalina.session.ManagerBase.backgroundProcess(ManagerBase.java:517)
        at org.apache.catalina.core.ContainerBase.backgroundProcess(ContainerBase.java:1352)
        at org.apache.catalina.core.ContainerBase$ContainerBackgroundProcessor.processChildren(ContainerBase.java:1530)
        at org.apache.catalina.core.ContainerBase$ContainerBackgroundProcessor.processChildren(ContainerBase.java:1540)
        at org.apache.catalina.core.ContainerBase$ContainerBackgroundProcessor.processChildren(ContainerBase.java:1540)
        at org.apache.catalina.core.ContainerBase$ContainerBackgroundProcessor.run(ContainerBase.java:1519)
        at java.lang.Thread.run(Thread.java:745)
```

This are actually two problems. First, the NPE.  The session ID changes due to the session fixation protection. Thus, the josso agent will register two sessions - one with the original id, a second with the new id.  When tomcat expires sessions, there will be two sessions with the same session id.  Only one will work. The latter will find a null which throws NPE that bubbles all the way up which prevented subsequent session listeners from releasing expired sessions. The fix simply tests for null. This allows all session listeners to proceed which frees half of the caches sessions.

Second, this still leaves behind the original session referenced by the original session ID. Since the session ID changed, the agent can no longer find and release the local session mapped by the original session id. This is an ugly hack, workaround that, when no session is found by ID, this uses brute force to go through the session cache looking for a match. Ideally, it would use a container listener to update the cache from the start but that's easier said than done and this works good enough.

More about [Tomcat session fixation protection](http://www.tomcatexpert.com/blog/2011/04/25/session-fixation-protection) .
