### PR TITLE
Fixed Node Id usage issues in agents

### DIFF
--- a/agents/josso-servlet-agent/src/main/java/org/josso/servlet/agent/GenericServletSSOAgent.java
+++ b/agents/josso-servlet-agent/src/main/java/org/josso/servlet/agent/GenericServletSSOAgent.java
@@ -131,7 +131,7 @@ public class GenericServletSSOAgent extends JaasHttpSSOAgent {
                 SSOIdentityManagerService im = request.getConfig(agent).getIdentityManagerService();
                 if (im == null) {
                     im = agent.getSSOIdentityManager();
-                    if (request.getNodeId() == null && !"".equals(request.getNodeId())) {
+                    if (request.getNodeId() != null && !"".equals(request.getNodeId())) {
                         im = agent.getSSOIdentityManager(request.getNodeId());
                     }
                 }

--- a/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/CatalinaNativeRealm.java
+++ b/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/CatalinaNativeRealm.java
@@ -57,8 +57,12 @@ public class CatalinaNativeRealm extends RealmBase {
             SSOAgent agent = Lookup.getInstance().lookupSSOAgent();
 
             SSOIdentityManagerService im = request.getConfig(agent).getIdentityManagerService();
-            if (im == null)
+            if (im == null) {
                 im = agent.getSSOIdentityManager();
+                if (request.getNodeId() != null && !"".equals(request.getNodeId())) {
+                    im = agent.getSSOIdentityManager(request.getNodeId());
+                }
+            }
 			
 			String requester = "";
 			// Check for nulls ?

--- a/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/SSOAgentValve.java
+++ b/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/SSOAgentValve.java
@@ -425,6 +425,7 @@ public class SSOAgentValve extends ValveBase
                 customAuthRequest.setRequest(hreq);
                 customAuthRequest.setResponse(hres);
                 customAuthRequest.setContext(request.getContext());
+                customAuthRequest.setNodeId(nodeId);
 
                 _agent.processRequest(customAuthRequest);
 
@@ -550,6 +551,7 @@ public class SSOAgentValve extends ValveBase
                 relayRequest.setRequest(hreq);
                 relayRequest.setResponse(hres);
                 relayRequest.setContext(request.getContext());
+                relayRequest.setNodeId(nodeId);
 
                 SingleSignOnEntry entry = _agent.processRequest(relayRequest);
                 if (entry == null) {
@@ -630,6 +632,7 @@ public class SSOAgentValve extends ValveBase
             r.setRequest(hreq);
             r.setResponse(hres);
             r.setContext(request.getContext());
+            r.setNodeId(nodeId);
 
             SingleSignOnEntry entry = _agent.processRequest(r);
 

--- a/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/jaas/SSOGatewayLoginModule.java
+++ b/agents/josso-tomcat70-agent/src/main/java/org/josso/tc70/agent/jaas/SSOGatewayLoginModule.java
@@ -164,8 +164,12 @@ public class SSOGatewayLoginModule implements LoginModule {
             SSOAgent agent = Lookup.getInstance().lookupSSOAgent();
 
             SSOIdentityManagerService im = request.getConfig(agent).getIdentityManagerService();
-            if (im == null)
+            if (im == null) {
                 im = agent.getSSOIdentityManager();
+                if (request.getNodeId() != null && !"".equals(request.getNodeId())) {
+                    im = agent.getSSOIdentityManager(request.getNodeId());
+                }
+            }
             SSOUser ssoUser = im.findUserInSession(_requester, ssoSessionId);
 
             logger.debug("Session authentication succeeded : " + ssoSessionId);
@@ -310,8 +314,12 @@ public class SSOGatewayLoginModule implements LoginModule {
             SSOAgent agent = Lookup.getInstance().lookupSSOAgent();
 
             SSOIdentityManagerService im = request.getConfig(agent).getIdentityManagerService();
-            if (im == null)
+            if (im == null) {
                 im = agent.getSSOIdentityManager();
+                if (request.getNodeId() != null && !"".equals(request.getNodeId())) {
+                    im = agent.getSSOIdentityManager(request.getNodeId());
+                }
+            }
 
             return im.findRolesBySSOSessionId(requester, _currentSSOSessionId);
         } catch(Exception e) {

--- a/agents/josso-tomcat80-agent/src/main/java/org/josso/tc80/agent/CatalinaNativeRealm.java
+++ b/agents/josso-tomcat80-agent/src/main/java/org/josso/tc80/agent/CatalinaNativeRealm.java
@@ -57,8 +57,12 @@ public class CatalinaNativeRealm extends RealmBase {
             SSOAgent agent = Lookup.getInstance().lookupSSOAgent();
 
             SSOIdentityManagerService im = request.getConfig(agent).getIdentityManagerService();
-            if (im == null)
+            if (im == null) {
                 im = agent.getSSOIdentityManager();
+                if (request.getNodeId() != null && !"".equals(request.getNodeId())) {
+                    im = agent.getSSOIdentityManager(request.getNodeId());
+                }
+            }
 			
 			String requester = "";
 			// Check for nulls ?

--- a/agents/josso-tomcat80-agent/src/main/java/org/josso/tc80/agent/SSOAgentValve.java
+++ b/agents/josso-tomcat80-agent/src/main/java/org/josso/tc80/agent/SSOAgentValve.java
@@ -425,6 +425,7 @@ public class SSOAgentValve extends ValveBase
                 customAuthRequest.setRequest(hreq);
                 customAuthRequest.setResponse(hres);
                 customAuthRequest.setContext(request.getContext());
+                customAuthRequest.setNodeId(nodeId);
 
                 _agent.processRequest(customAuthRequest);
 
@@ -550,6 +551,7 @@ public class SSOAgentValve extends ValveBase
                 relayRequest.setRequest(hreq);
                 relayRequest.setResponse(hres);
                 relayRequest.setContext(request.getContext());
+                relayRequest.setNodeId(nodeId);
 
                 SingleSignOnEntry entry = _agent.processRequest(relayRequest);
                 if (entry == null) {
@@ -630,6 +632,7 @@ public class SSOAgentValve extends ValveBase
             r.setRequest(hreq);
             r.setResponse(hres);
             r.setContext(request.getContext());
+            r.setNodeId(nodeId);
 
             SingleSignOnEntry entry = _agent.processRequest(r);
 

--- a/agents/josso-tomcat80-agent/src/main/java/org/josso/tc80/agent/jaas/SSOGatewayLoginModule.java
+++ b/agents/josso-tomcat80-agent/src/main/java/org/josso/tc80/agent/jaas/SSOGatewayLoginModule.java
@@ -164,8 +164,12 @@ public class SSOGatewayLoginModule implements LoginModule {
             SSOAgent agent = Lookup.getInstance().lookupSSOAgent();
 
             SSOIdentityManagerService im = request.getConfig(agent).getIdentityManagerService();
-            if (im == null)
+            if (im == null) {
                 im = agent.getSSOIdentityManager();
+                if (request.getNodeId() != null && !"".equals(request.getNodeId())) {
+                    im = agent.getSSOIdentityManager(request.getNodeId());
+                }
+            }
             SSOUser ssoUser = im.findUserInSession(_requester, ssoSessionId);
 
             logger.debug("Session authentication succeeded : " + ssoSessionId);
@@ -310,8 +314,12 @@ public class SSOGatewayLoginModule implements LoginModule {
             SSOAgent agent = Lookup.getInstance().lookupSSOAgent();
 
             SSOIdentityManagerService im = request.getConfig(agent).getIdentityManagerService();
-            if (im == null)
+            if (im == null) {
                 im = agent.getSSOIdentityManager();
+                if (request.getNodeId() != null && !"".equals(request.getNodeId())) {
+                    im = agent.getSSOIdentityManager(request.getNodeId());
+                }
+            }
 
             return im.findRolesBySSOSessionId(requester, _currentSSOSessionId);
         } catch(Exception e) {

--- a/core/josso-agent/src/main/java/org/josso/agent/http/NativeHttpSSOAgent.java
+++ b/core/josso-agent/src/main/java/org/josso/agent/http/NativeHttpSSOAgent.java
@@ -56,8 +56,12 @@ public class NativeHttpSSOAgent extends HttpSSOAgent {
             }
 
             SSOIdentityManagerService im = request.getConfig(this).getIdentityManagerService();
-            if (im == null)
+            if (im == null) {
                 im = getSSOIdentityManager();
+                if (request.getNodeId() != null && !"".equals(request.getNodeId())) {
+                    im = getSSOIdentityManager(request.getNodeId());
+                }
+            }
 
             SSOUser ssoUser = im.findUserInSession(request.getRequester(), ssoSessionId);
             


### PR DESCRIPTION
Fixed Node Id usage issues in tc70, tc80 and servlet agents, in order to use node id when it is not null and not empty