### PR TITLE
Fix josso-agent-config.xml for Tomcat 6 - 8.5

### DIFF
--- a/distributions/josso/src/main/resources/dist/agents/config/tc60/josso-agent-config.xml
+++ b/distributions/josso/src/main/resources/dist/agents/config/tc60/josso-agent-config.xml
@@ -24,7 +24,7 @@
 <s:beans xmlns:s="http://www.springframework.org/schema/beans"
          xmlns:tc60="urn:org:josso:agent:tomcat60"
          xmlns:agent="urn:org:josso:agent:core"
-         xmlns:protocol="urn:org:josso:protocol:client"
+         xmlns:protocol="urn:org:josso:protocol:client:jaxws"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
          urn:org:josso:agent:tomcat60 http://www.josso.org/schema/josso-tomcat60-agent.xsd
@@ -39,10 +39,10 @@
 
         <!-- Gateway service locator -->
         <gatewayServiceLocator>
-            <!-- Other properties for ws-service-locator :
+            <!-- Other properties for jaxws-service-locator :
             username, password, servicesWebContext, transportSecurity
             -->
-            <protocol:ws-service-locator endpoint="localhost:8080" />
+            <protocol:jaxws-service-locator endpoint="localhost:8080" />
         </gatewayServiceLocator>
 
         <configuration>

--- a/distributions/josso/src/main/resources/dist/agents/config/tc70/josso-agent-config.xml
+++ b/distributions/josso/src/main/resources/dist/agents/config/tc70/josso-agent-config.xml
@@ -24,7 +24,7 @@
 <s:beans xmlns:s="http://www.springframework.org/schema/beans"
          xmlns:tc70="urn:org:josso:agent:tomcat70"
          xmlns:agent="urn:org:josso:agent:core"
-         xmlns:protocol="urn:org:josso:protocol:client"
+         xmlns:protocol="urn:org:josso:protocol:client:jaxws"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
          urn:org:josso:agent:tomcat70 http://www.josso.org/schema/josso-tomcat70-agent.xsd
@@ -39,10 +39,10 @@
 
         <!-- Gateway service locator -->
         <gatewayServiceLocator>
-            <!-- Other properties for ws-service-locator :
+            <!-- Other properties for jaxws-service-locator :
             username, password, servicesWebContext, transportSecurity
             -->
-            <protocol:ws-service-locator endpoint="localhost:8080" />
+            <protocol:jaxws-service-locator endpoint="localhost:8080" />
         </gatewayServiceLocator>
 
         <configuration>

--- a/distributions/josso/src/main/resources/dist/agents/config/tc80/josso-agent-config.xml
+++ b/distributions/josso/src/main/resources/dist/agents/config/tc80/josso-agent-config.xml
@@ -24,7 +24,7 @@
 <s:beans xmlns:s="http://www.springframework.org/schema/beans"
          xmlns:tc80="urn:org:josso:agent:tomcat80"
          xmlns:agent="urn:org:josso:agent:core"
-         xmlns:protocol="urn:org:josso:protocol:client"
+         xmlns:protocol="urn:org:josso:protocol:client:jaxws"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
          urn:org:josso:agent:tomcat80 http://www.josso.org/schema/josso-tomcat80-agent.xsd
@@ -39,10 +39,10 @@
 
         <!-- Gateway service locator -->
         <gatewayServiceLocator>
-            <!-- Other properties for ws-service-locator :
+            <!-- Other properties for jaxws-service-locator :
             username, password, servicesWebContext, transportSecurity
             -->
-            <protocol:ws-service-locator endpoint="localhost:8080" />
+            <protocol:jaxws-service-locator endpoint="localhost:8080" />
         </gatewayServiceLocator>
 
         <configuration>

--- a/distributions/josso/src/main/resources/dist/agents/config/tc85/josso-agent-config.xml
+++ b/distributions/josso/src/main/resources/dist/agents/config/tc85/josso-agent-config.xml
@@ -24,7 +24,7 @@
 <s:beans xmlns:s="http://www.springframework.org/schema/beans"
          xmlns:tc85="urn:org:josso:agent:tomcat85"
          xmlns:agent="urn:org:josso:agent:core"
-         xmlns:protocol="urn:org:josso:protocol:client"
+         xmlns:protocol="urn:org:josso:protocol:client:jaxws"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
          urn:org:josso:agent:tomcat85 http://www.josso.org/schema/josso-tomcat85-agent.xsd
@@ -39,10 +39,10 @@
 
         <!-- Gateway service locator -->
         <gatewayServiceLocator>
-            <!-- Other properties for ws-service-locator :
+            <!-- Other properties for jaxws-service-locator :
             username, password, servicesWebContext, transportSecurity
             -->
-            <protocol:ws-service-locator endpoint="localhost:8080" />
+            <protocol:jaxws-service-locator endpoint="localhost:8080" />
         </gatewayServiceLocator>
 
         <configuration>

--- a/distributions/josso/src/main/resources/dist/agents/config/tc85/josso-agent-config.xml
+++ b/distributions/josso/src/main/resources/dist/agents/config/tc85/josso-agent-config.xml
@@ -22,12 +22,12 @@
   -->
 
 <s:beans xmlns:s="http://www.springframework.org/schema/beans"
-         xmlns:tc85="urn:org:josso:agent:tomcat80"
+         xmlns:tc85="urn:org:josso:agent:tomcat85"
          xmlns:agent="urn:org:josso:agent:core"
          xmlns:protocol="urn:org:josso:protocol:client"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-         urn:org:josso:agent:tomcat80 http://www.josso.org/schema/josso-tomcat80-agent.xsd
+         urn:org:josso:agent:tomcat85 http://www.josso.org/schema/josso-tomcat85-agent.xsd
          urn:org:josso:agent:core http://www.josso.org/schema/josso-agent.xsd
          urn:org:josso:protocol:client http://www.josso.org/schema/josso-protocol-client.xsd">
 


### PR DESCRIPTION
For Tomcat 6 - 8.5 use jaxws in the josso-agent-config.xml instead of axis which is not used for this Tomcat versions.

Fixed the xbeans paths in the josso-agent-config.xml of Tomcat 8.5